### PR TITLE
Fix syntax of string comparison against 'disable'

### DIFF
--- a/init-pants/action.yaml
+++ b/init-pants/action.yaml
@@ -156,7 +156,7 @@ runs:
 
     - name: Cache Pants named caches
       uses: actions/cache@v4
-      if: inputs.named-caches-hash != "disable"
+      if: inputs.named-caches-hash != 'disable'
       with:
         path: ${{ inputs.named-caches-location }}
         key: pants-named-caches-${{ runner.os }}-${{ inputs.gha-cache-key }}-${{ hashFiles('pants.toml') }}-${{ inputs.named-caches-hash }}


### PR DESCRIPTION
Programming in YAML is painful, I think it's interpreting the `"` before GitHub can.